### PR TITLE
PANDARIA: cut out the alert message that is too long

### DIFF
--- a/pkg/providers/aliyunsms/aliyunsms.go
+++ b/pkg/providers/aliyunsms/aliyunsms.go
@@ -22,6 +22,9 @@ const (
 	signNameKey     = "sign_name"
 	templateCodeKey = "template_code"
 	proxyURLKey     = "proxy_url"
+
+	//PANDARIA: aliyun sms alert message limit
+	aliyunMsgLimit = 900
 )
 
 type sender struct {
@@ -38,6 +41,10 @@ type aliyunResponse struct {
 }
 
 func (s *sender) Send(msg string, receiver providers.Receiver) error {
+	if len(msg) > aliyunMsgLimit {
+		msg = msg[:aliyunMsgLimit]
+	}
+
 	if s.proxyURL != "" {
 		s.client.SetHttpsProxy(s.proxyURL)
 	}

--- a/pkg/providers/dingtalk/dingtalk.go
+++ b/pkg/providers/dingtalk/dingtalk.go
@@ -22,6 +22,9 @@ const (
 	webhookURLKey = "webhook_url"
 	secretKey     = "secret"
 	proxyURLKey   = "proxy_url"
+
+	//PANDARIA: dingtalk alert message limit
+	dingtalkMsgLimit = 19000
 )
 
 type sender struct {
@@ -48,6 +51,10 @@ func New(opt map[string]string) (providers.Sender, error) {
 }
 
 func (s *sender) Send(msg string, receiver providers.Receiver) error {
+	if len(msg) > dingtalkMsgLimit {
+		msg = msg[:dingtalkMsgLimit]
+	}
+
 	payload, err := newPayload(msg)
 	if err != nil {
 		return err
@@ -95,7 +102,7 @@ func (s *sender) Send(msg string, receiver providers.Receiver) error {
 		return err
 	}
 	if dtr.ErrCode != 0 {
-		return fmt.Errorf("dingtalk response errcode:%d", dtr.ErrCode)
+		return fmt.Errorf("dingtalk response errcode: %d, errmsg: %s", dtr.ErrCode, dtr.ErrMsg)
 	}
 
 	return nil


### PR DESCRIPTION
实际对钉钉和阿里云短信接收消息大小极限的验证过程中发现：

- 钉钉：发送的内容（payload，包含json包装后的内容）超过20362字节后，钉钉会返回错误。因此对标的告警信息（msg）大小为19309字节，因此以告警信息19000个字节为极限进行截断

- 阿里云短信：告警信息（msg）大小超过959个字节后，阿里云短信返回错误。因此以告警信息900个字节为极限进行截断

**Relate issue：**
https://github.com/cnrancher/pandaria/issues/965