### PR TITLE
PANDARIA: change aliyun msg limit

### DIFF
--- a/pkg/providers/aliyunsms/aliyunsms.go
+++ b/pkg/providers/aliyunsms/aliyunsms.go
@@ -24,7 +24,7 @@ const (
 	proxyURLKey     = "proxy_url"
 
 	//PANDARIA: aliyun sms alert message limit
-	aliyunMsgLimit = 900
+	aliyunMsgLimit = 600
 )
 
 type sender struct {


### PR DESCRIPTION
目前设置的900个字节限制，往阿里云发送信息返回“OK”，不会有之前的错误 `send msg err: failed to send Aliyun SMS message. templateParams over length limit 1000 bytes`，但阿里云那边并没有往外发出短信（不清楚那边的具体判断逻辑），现将限制设为600个字节，无论全中文或全英文短信都能正常接收，也为用户的短信模版长度预留空间

**Relate issue:**
https://github.com/cnrancher/pandaria/issues/965